### PR TITLE
Abort script on error

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 TOOLBOX_DOCKER_IMAGE=fedora
 TOOLBOX_DOCKER_TAG=latest
 TOOLBOX_USER=root


### PR DESCRIPTION
Abort the `toolbox` script immediately if an error occurs rather than ignoring them.